### PR TITLE
Explicitly configure the port for catalogue to be 80 in kubernetes/manifests

### DIFF
--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -29,6 +29,7 @@ spec:
                 key: password
         command: ["/app"]
         args:
+          - -port=80
           - -DSN
           - "$(DB_USERNAME):$(DB_PASSWORD)@tcp(catalogdb-beautiful-gopher.c1rdvgzogyh3.us-west-2.rds.amazonaws.com:3306)/socksdb"
         resources:

--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -39,7 +39,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 8081
+        - containerPort: 80
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
@@ -52,13 +52,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 8081
+            port: 80
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 8081
+            port: 80
           initialDelaySeconds: 180
           periodSeconds: 3
       nodeSelector:

--- a/deploy/kubernetes/manifests/catalogue-svc.yaml
+++ b/deploy/kubernetes/manifests/catalogue-svc.yaml
@@ -10,6 +10,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 8081
+    targetPort: 80
   selector:
     name: catalogue


### PR DESCRIPTION
Changelog:
- Revert "catalogue listens on port 8081"
- Explicitly configure the port for `catalogue` to be `80` in `kubernetes/manifests`

See also: microservices-demo/microservices-demo/pull/767